### PR TITLE
React 0.12 support and remove JSX

### DIFF
--- a/Container.js
+++ b/Container.js
@@ -11,13 +11,7 @@ var Container = React.createClass({
     // TODO: swap out to use ES6-7 spread operator when possible
     // @see https://gist.github.com/sebmarkbage/a6e220b7097eb3c79ab7
     // return <div {...this.props}>{this.props.children}{this.renderContainer()}</div>;
-    return this.transferPropsTo(
-      <div>
-        {this.props.children}
-
-        {this.renderContainer()}
-      </div>
-      );
+    return this.transferPropsTo(React.DOM.div(null, this.props.children, this.renderContainer()));
   }
 });
 

--- a/ContainerMixin.js
+++ b/ContainerMixin.js
@@ -26,7 +26,7 @@ var ContainerMixin = {
   },
 
   renderContainer: function() {
-    return <div ref="container" />;
+    return React.DOM.div({ref:"container"});
   }
 };
 

--- a/Layer.js
+++ b/Layer.js
@@ -18,7 +18,7 @@ var Layer = React.createClass({
     // @see https://gist.github.com/sebmarkbage/a6e220b7097eb3c79ab7
     // var {container, layer, ...props} = this.props;
     // return <div {...props}>{this.props.children}</div>;
-    return this.transferPropsTo(<div container={null} layer={null}>{this.props.children}</div>);
+    return this.transferPropsTo(React.DOM.div({container: null, layer: null}, this.props.children));
   },
 
   renderLayer: function() {

--- a/LayerMixin.js
+++ b/LayerMixin.js
@@ -80,7 +80,7 @@ var LayerMixin = {
       return;
     }
 
-    if (!React.isValidComponent(layer)) {
+    if (!React.isValidElement(layer)) {
       throw new Error(
         (this.constructor.displayName || 'ReactCompositeComponent') +
           '.renderLayer(): A valid ReactComponent must be returned. You may have ' +

--- a/Portal.js
+++ b/Portal.js
@@ -19,7 +19,7 @@ var Portal = React.createClass({
     // @see https://gist.github.com/sebmarkbage/a6e220b7097eb3c79ab7
     // var {container, ...props} = this.props;
     // return <div {...props}>{this.props.children}</div>;
-    return cloneWithProps(<div container={null}>{this.props.children}</div>, this.props);
+    return cloneWithProps(React.DOM.div({container: null}, this.props.children), this.props);
   }
 });
 

--- a/modules/ReactLayer.js
+++ b/modules/ReactLayer.js
@@ -24,7 +24,7 @@ function ReactLayer(container) {
 ReactLayer.prototype.render = function(nextDescriptor) {
   this.__nextDescriptor = nextDescriptor;
   if (this.__container) {
-    React.renderComponent(nextDescriptor, this.__container);
+    React.render(nextDescriptor, this.__container);
   }
 };
 


### PR DESCRIPTION
Hello,

I was trying to add react-layers to my browserify/reactify solution but I had no easy means to compile the JSX that was in the module when bundling my app.
So I simply rewrote the JSX bits into plain JS, and I figured this could be helpful for everyone so I'm making this pull request.

I also included another commit from jkk, who had already forked before me, to support React 0.12

Cheers,
Damien
